### PR TITLE
339 network requests on login and register pages sending passwords back to the user

### DIFF
--- a/Site/src/routes/(main)/admin/accounts/+page.server.ts
+++ b/Site/src/routes/(main)/admin/accounts/+page.server.ts
@@ -31,6 +31,7 @@ actions.changePassword = async ({ request, locals, getClientAddress }) => {
 	if (limit) return limit
 
 	const { username, password } = form.data
+	form.data.password = ""
 
 	try {
 		await equery(

--- a/Site/src/routes/(main)/admin/banners/+page.server.ts
+++ b/Site/src/routes/(main)/admin/banners/+page.server.ts
@@ -46,6 +46,7 @@ async function bannerActiveCount() {
 async function getData({ request, locals }: RequestEvent) {
 	const { user } = await authorise(locals, 5)
 	const form = await superValidate(request, zod(schema))
+
 	return { user, form, error: !form.valid && formError(form) }
 }
 

--- a/Site/src/routes/(main)/admin/banners/+page.svelte
+++ b/Site/src/routes/(main)/admin/banners/+page.svelte
@@ -20,12 +20,6 @@
 		["fa-plus", "fa-list"]
 	)
 	let textLightForms: { [k: string]: HTMLFormElement } = {}
-	let bannerData = {
-		id: "",
-		bgColour: "",
-		textLight: false,
-		body: ""
-	}
 
 	const formData = superForm(data.form)
 	export const snapshot = formData

--- a/Site/src/routes/(main)/admin/create/+page.server.ts
+++ b/Site/src/routes/(main)/admin/create/+page.server.ts
@@ -225,6 +225,7 @@ actions.autopilot = async ({ request, locals }) => {
 	await authorise(locals, 3)
 	const form = await superValidate(request, zod(schemaAuto))
 	if (!form.valid) return formError(form)
+
 	const { data } = form
 
 	if (!fs.existsSync("../data/assets")) fs.mkdirSync("../data/assets")

--- a/Site/src/routes/(main)/admin/regkeys/+page.server.ts
+++ b/Site/src/routes/(main)/admin/regkeys/+page.server.ts
@@ -1,14 +1,14 @@
+import config from "$lib/server/config.ts"
 import formError from "$lib/server/formError"
 import { authorise } from "$lib/server/lucia"
 import ratelimit from "$lib/server/ratelimit"
 import { Record, equery, surql } from "$lib/server/surreal"
+import { error } from "@sveltejs/kit"
 import { zod } from "sveltekit-superforms/adapters"
 import { message, superValidate } from "sveltekit-superforms/server"
 import { z } from "zod"
 import type { RequestEvent } from "./$types.ts"
 import regKeysQuery from "./regKeys.surql"
-import config from "$lib/server/config.ts"
-import { error } from "@sveltejs/kit"
 
 const schema = z.object({
 	enableRegKeyCustom: z.boolean().optional(),
@@ -38,15 +38,11 @@ export async function load({ locals }) {
 	}
 }
 
-async function getData(e: RequestEvent) {
-	const { user } = await authorise(e.locals, 5)
-	const form = await superValidate(e.request, zod(schema))
+async function getData({ request, locals }: RequestEvent) {
+	const { user } = await authorise(locals, 5)
+	const form = await superValidate(request, zod(schema))
 
-	return {
-		user,
-		form,
-		error: !form.valid && formError(form),
-	}
+	return { user, form, error: !form.valid && formError(form) }
 }
 
 const chars = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/Site/src/routes/(main)/place/[id=integer]/[name]/settings/+page.server.ts
+++ b/Site/src/routes/(main)/place/[id=integer]/[name]/settings/+page.server.ts
@@ -79,9 +79,9 @@ export async function load({ locals, params }) {
 	}
 }
 
-async function getData(e: RequestEvent) {
-	const { user } = await authorise(e.locals)
-	const id = +e.params.id
+async function getData({ locals, params }: RequestEvent) {
+	const { user } = await authorise(locals)
+	const id = +params.id
 	const getPlace = await placeQuery(id)
 	if (user.username !== getPlace.owner.username && user.permissionLevel < 4)
 		error(403, "You do not have permission to update this page.")

--- a/Site/src/routes/(main)/settings/+page.server.ts
+++ b/Site/src/routes/(main)/settings/+page.server.ts
@@ -49,6 +49,9 @@ actions.password = async ({ request, locals }) => {
 	if (!form.valid) return formError(form)
 
 	const { cpassword, npassword, cnpassword } = form.data
+	// Don't send the password back to the client
+	form.data.cpassword = form.data.npassword = form.data.cnpassword = ""
+
 	if (npassword !== cnpassword)
 		return formError(form, ["cnpassword"], ["Passwords do not match"])
 	if (npassword === cpassword)
@@ -67,9 +70,6 @@ actions.password = async ({ request, locals }) => {
 
 	await equery(surql`
 		UPDATE ${userId} SET hashedPassword = ${Bun.password.hashSync(npassword)}`)
-
-	// Don't send the password back to the client
-	form.data.cpassword = form.data.npassword = form.data.cnpassword = ""
 
 	return message(form, "Password updated successfully!")
 }

--- a/Site/src/routes/(plain)/login/+page.server.ts
+++ b/Site/src/routes/(plain)/login/+page.server.ts
@@ -42,6 +42,7 @@ actions.default = async ({ request, cookies }) => {
 	if (!form.valid) return formError(form)
 
 	const { username, password } = form.data
+	form.data.password = ""
 
 	const [[user]] = await equery<
 		{

--- a/Site/src/routes/(plain)/register/+page.server.ts
+++ b/Site/src/routes/(plain)/register/+page.server.ts
@@ -55,7 +55,9 @@ export const actions: import("./$types").Actions = {}
 actions.register = async ({ request, cookies }) => {
 	const form = await superValidate(request, zod(schema))
 	if (!form.valid) return formError(form)
+
 	const { username, email, password, cpassword } = form.data
+	form.data.password = form.data.cpassword = ""
 
 	if (cpassword !== password)
 		return formError(
@@ -125,7 +127,9 @@ actions.register = async ({ request, cookies }) => {
 actions.initialAccount = async ({ request, cookies }) => {
 	const form = await superValidate(request, zod(schemaInitial))
 	if (!form.valid) return formError(form)
+
 	const { username, password, cpassword } = form.data
+	form.data.password = form.data.cpassword = ""
 
 	if (cpassword !== password)
 		return formError(


### PR DESCRIPTION
Closes #339 by removing sensitive data from error messages before returning them