### PR TITLE
Revert "Bump @sveltejs/kit from 2.42.2 to 2.46.5 in /Site"

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -24,7 +24,7 @@
 		"@melt-ui/pp": "^0.3.2",
 		"@melt-ui/svelte": "^0.86.6",
 		"@sveltejs/adapter-node": "^5.3.3",
-		"@sveltejs/kit": "2.46",
+		"@sveltejs/kit": "2.42",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@unocss/core": "^66.5.2",
 		"@unocss/extractor-svelte": "^66.5.2",


### PR DESCRIPTION
Reverts tp-link-extender/MercuryCore#412, as the "Error -1" issue is still present